### PR TITLE
Added class="no-change-track" to checkbox

### DIFF
--- a/templates/GridFieldPaginatorWithShowAll_Row.ss
+++ b/templates/GridFieldPaginatorWithShowAll_Row.ss
@@ -1,7 +1,7 @@
 <tr>
 	<td class="bottom-all paginator extra" colspan="$Colspan">
 		<div class="gridfield-pagination-showall">
-			<input type="checkbox" id="{$ID}_ShowAllSwitch" value="1" $Checked/> <label for="{$ID}_ShowAllSwitch"><% _t('GridFieldPaginatorWithShowAll.SHOWALL', 'Show all') %></label>
+			<input type="checkbox" class="no-change-track" id="{$ID}_ShowAllSwitch" value="1" $Checked/> <label for="{$ID}_ShowAllSwitch"><% _t('GridFieldPaginatorWithShowAll.SHOWALL', 'Show all') %></label>
 		</div>
 		<% if $OnlyOnePage %>
 		<% else %>


### PR DESCRIPTION
CMS will no longer ask if you are sure to you want to navigate away, when you just change the list view (nothing to save)
